### PR TITLE
[FIX] `path` isn't depeendency of the importing package

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -297,7 +297,7 @@ packages:
     source: hosted
     version: "1.0.0"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   flutter_tts: ^4.0.2
   image_picker: ^1.0.4
   permission_handler: ^11.0.1
+  path: ^1.9.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Description

### Fixed

- `path` isn't depeendency of the importing package in  [lib/services/database_helper.dart#L2](https://github.com/x-actly/picto_grid_android/blob/main/lib/services/database_helper.dart#L2)

### Type of Changes
Please select the type of changes made in this pull request:
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Other (please specify):

### Checklist
Please ensure the following before submitting your pull request:
- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] All new and existing tests passed.
