### PR TITLE
[FIX] Increase pictograms per row in search from 3 to 7

### DIFF
--- a/lib/widgets/pictogram_selection_dialog.dart
+++ b/lib/widgets/pictogram_selection_dialog.dart
@@ -530,10 +530,10 @@ class _LocalPictogramSearchWidgetState
                 )
               : GridView.builder(
                   gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: 3,
-                    childAspectRatio: 1.0,
-                    crossAxisSpacing: 8,
-                    mainAxisSpacing: 8,
+                    crossAxisCount: 7,
+                    childAspectRatio: 0.9,
+                    crossAxisSpacing: 6,
+                    mainAxisSpacing: 6,
                   ),
                   itemCount: _searchResults.length,
                   itemBuilder: (context, index) {
@@ -546,7 +546,7 @@ class _LocalPictogramSearchWidgetState
                           children: [
                             Expanded(
                               child: Padding(
-                                padding: const EdgeInsets.all(8.0),
+                                padding: const EdgeInsets.all(4.0),
                                 child: pictogram.imageUrl.startsWith('assets/')
                                     ? Image.asset(
                                         pictogram.imageUrl,
@@ -585,12 +585,12 @@ class _LocalPictogramSearchWidgetState
                               ),
                             ),
                             Padding(
-                              padding: const EdgeInsets.all(4.0),
+                              padding: const EdgeInsets.all(2.0),
                               child: Text(
                                 pictogram.keyword,
                                 textAlign: TextAlign.center,
-                                style: const TextStyle(fontSize: 12),
-                                maxLines: 2,
+                                style: const TextStyle(fontSize: 10),
+                                maxLines: 1,
                                 overflow: TextOverflow.ellipsis,
                               ),
                             ),


### PR DESCRIPTION
## Description


## Improve Search Grid Layout

Increased the number of pictograms displayed per row in the search function from 3 to 7 for better overview and faster browsing.

### Changes:
- Updated `crossAxisCount` from 3 to 7 in search grid
- Adjusted spacing and text size for compact display
- Optimized padding for better visual balance

### Benefits:
- More pictograms visible at once
- Reduced scrolling needed during search
- Improved user experience for pictogram selection


### Type of Changes
Please select the type of changes made in this pull request:
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation Update
- [x] Other (please specify):

### Checklist
Please ensure the following before submitting your pull request:
- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] All new and existing tests passed.
